### PR TITLE
Update nvidia-efa-ml-al2-eks.yml

### DIFF
--- a/nvidia-efa-ami_base/nvidia-efa-ml-al2-eks.yml
+++ b/nvidia-efa-ami_base/nvidia-efa-ml-al2-eks.yml
@@ -4,7 +4,7 @@
     "flag": "eks-1.20",
     "subnet_id": "subnet-baff22e5",
     "security_groupids": "sg-053996a563511a3c6,sg-050407dfb1c555723",
-    "build_ami": "ami-0ee7f482baec5230f",
+    "build_ami": "ami-00e3a92bc8dc6c066",
     "efa_pkg": "aws-efa-installer-latest.tar.gz",
     "intel_mkl_version": "intel-mkl-2020.0-088",
     "nvidia_version": "510.47.03",


### PR DESCRIPTION
`ami-0ee7f482baec5230f` from October - does not contain G5 instances in the `eni-max-pods.txt` file , AMI was not Updated until after Nov to support G5 instances - https://github.com/awslabs/amazon-eks-ami/commit/4540137497170115ce79652c45ac662049201720

*Issue #, if available:*

*Description of changes:*

Updated to AMI with G5 instances support 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
